### PR TITLE
[Add] rspec 2&3

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,10 @@ class Item < ApplicationRecord
     greater_than: 0 }
 	validates :is_sale, inclusion: { in: [true, false] }
 
-  	attachment :image
+	attachment :image
+	
+	# 注文回数が多い商品を検索（デフォルト：上位4件抽出）
+	scope :recommend_list, -> (count: 4){ left_joins(:order_items).group(:item_id).order("count(order_items.id) desc").limit(count) }
 
 	# 税込価格を取得
 	def price_tax_included(tax: 1.08)

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -48,7 +48,7 @@
             </thead>
             <tbody>
                 <% @order_items.each do |order_item| %>
-                    <tr>
+                    <tr id=<%= "order-item-field-#{order_item.id}" %>>
                         <td><%= order_item.item.name %></td> 
                         <td><%= order_item.price  %></td>
                         <td><%= order_item.item_count %></td>

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:title, '管理者ログイン') %>
+<%= render "layouts/flash" %>
 <div class="row">
   <div class="col-xs-4 col-xs-offset-2"><h3>管理者ログイン</h3></div>
 </div>
 <div class="row">
   <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "form-horizontal" }) do |f| %>
-  <%= render "layouts/flash" %>
 
     <div class="form-group">
       <%= f.label :email, "メールアドレス", class: "control-label col-xs-4" %>

--- a/app/views/client/orders/confirm.html.erb
+++ b/app/views/client/orders/confirm.html.erb
@@ -5,10 +5,11 @@
 </div>
 
 <div class="row">
+    <div class="col-xs-8">
     <table class="table">
         <thead>
             <tr class="active">
-                <th class="text-center">>商品名</th>
+                <th class="text-center">商品名</th>
                 <th class="text-center">単価（税込）</th>
                 <th class="text-center">数量</th>
                 <th class="text-center">小計</th>
@@ -17,39 +18,39 @@
         <tbody>
             <% current_client.cart_items.each do |cart_item| %>
             <tr>
-                <td class="text-right"><%= cart_item.item.name %></td>
-                <td class="text-right"><%= cart_item.item.price_tax_included %></td>
-                <td class="text-right"><%= cart_item.item_count %></td>
-                <% end %>
-                <td class="text-right"><%= @cart_total_fee %></td>
+                <td class="text-center"><%= cart_item.item.name %></td>
+                <td class="text-center"><%= cart_item.item.price_tax_included %>円</td>
+                <td class="text-center"><%= cart_item.item_count %></td>
+                <td class="text-center"><%= cart_item.subtotal %>円</td>
             </tr>
+            <% end %>
         </tbody>
     </table>
-</div>
-
-<div class="row">
-    <table class="table">
-        <tbody>
-            <tr>
-                <th class="active">送料</th>
-                <td class="text-right"><%= @order.postage %>円</td>
-            </tr>
-            <tr>
-                <th class="active">商品合計</th>
-                <td class="text-right"><%= @cart_total_fee %></td>
-            </tr>
-            <tr>
-                <th class="active">請求金額</th>
-                <td class="text-right"><%= @order.total_fee %>円</td>
-            </tr>
-        </tbody>
-    </table>
+    </div>
+    <div class="col-xs-4">
+        <table class="table">
+            <tbody>
+                <tr>
+                    <th class="active">送料</th>
+                    <td class="text-right"><%= @order.postage %>円</td>
+                </tr>
+                <tr>
+                    <th class="active">商品合計</th>
+                    <td class="text-right"><%= @cart_total_fee %>円</td>
+                </tr>
+                <tr>
+                    <th class="active">請求金額</th>
+                    <td class="text-right"><%= @order.total_fee %>円</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 </div>
 
 <div class="row">
     <table>
         <tr>
-            <th class="col-xs-4">お支払い方法</th>
+            <th class="col-xs-4">支払方法</th>
             <td class="col-xs-8"><%= @order.payment_method_i18n %></td>
         </tr>
         <tr>
@@ -63,12 +64,14 @@
 </div>
 
 <div class="row">
-    <%= form_for @order do |f| %>
-    <%= f.hidden_field :post_number, value: @order.post_number %>
-    <%= f.hidden_field :total_fee, value: @order.total_fee %>
-    <%= f.hidden_field :address, value: @order.address %>
-    <%= f.hidden_field :receiver, value: @order.receiver %>
-    <%= f.hidden_field :payment_method, value: @order.payment_method %>
-    <%= f.submit "購入を確定する", class:"btn btn-success" %>
-    <% end %>
+    <div class="col-xs-4 col-xs-offset-4">
+        <%= form_for @order do |f| %>
+        <%= f.hidden_field :post_number, value: @order.post_number %>
+        <%= f.hidden_field :total_fee, value: @order.total_fee %>
+        <%= f.hidden_field :address, value: @order.address %>
+        <%= f.hidden_field :receiver, value: @order.receiver %>
+        <%= f.hidden_field :payment_method, value: @order.payment_method %>
+        <%= f.submit "購入を確定する", class:"btn origin-btn" %>
+        <% end %>
+    </div>
 </div>

--- a/app/views/client/orders/new.html.erb
+++ b/app/views/client/orders/new.html.erb
@@ -4,73 +4,72 @@
         <h2 class="col-xs-4">注文情報入力</h2>
     </div>
 </div>
-
-<div class="row">
-    <div class="col-xs-offset-2">
-        <h4>支払い方法</h4>
-        <%= form_for(@order, url: confirm_orders_path) do |f| %>
-        <div class="payment-method">
-            <div>
-                <%= f.radio_button :payment_method, :credit_card, checked: true %>
-                <%= f.label :credit_card, "クレジットカード" %>
-                ​</div>
-            <div>
-                <%= f.radio_button :payment_method, :bank_transfer %>
-                <%= f.label :credit_card, "銀行振込" %>
+<%= form_for(@order, url: confirm_orders_path) do |f| %>
+    <div class="row">
+        <div class="col-xs-offset-2">
+            <h4>支払方法</h4>
+            <div class="payment-method">
+                <div>
+                    <%= f.radio_button :payment_method, :credit_card, checked: true %>
+                    <%= f.label :credit_card, "クレジットカード" %>
+                    ​</div>
+                <div>
+                    <%= f.radio_button :payment_method, :bank_transfer %>
+                    <%= f.label :credit_card, "銀行振込" %>
+                </div>
             </div>
         </div>
     </div>
-</div>
 
-<div class="row">
-    <div class="col-xs-offset-2">
-        <h4>お届け先</h4>
-        <div class="addressee">
-            <table class="addressee-form-table">
-                <tbody>
-                    <tr>
-                        <%= radio_button_tag :address, "ご自身の住所", checked: true %>
-                        <%= f.label(:address, "ご自身の住所") %>
-                        <p class="address">
-                            <%= current_client.post_number %>
-                            <%= current_client.address %>
-                            <%= current_client.get_full_name %>
-                        </p>
-                    </tr>
-                    <tr>
-                        <%= radio_button_tag :address, "登録済住所から選択" %>
-                        <%= f.label(:receiver, "登録済住所から選択") %>
-                        <%= f.fields_for @delivery do |t| %>
-                        <p class="address">
-                            <%= select_tag 'delivery_id', options_for_select(current_client.deliveries.map { |delivery| [delivery.post_number + " " + delivery.address + " " + delivery.receiver, delivery.id] }) %>
-                        </p>
-                        <% end %>
-                    </tr>
-                    <tr>
-                        <%= radio_button_tag :address, "新しいお届け先" %>
-                        <%= f.label(:address, "新しいお届け先") %>
-                    </tr>
-                    <tr>
-                        <td><%= f.label(:post_number, "郵便番号") %></td>
-                        <td><%= f.text_field :post_number, class: "form-control" %></td>
-                    </tr>
-                    <tr>
-                        <td><%= f.label(:address, "住所") %></td>
-                        <td><%= f.text_field :address, class: "form-control" %></td>
-                    </tr>
-                    <tr>
-                        <td><%= f.label(:receiver, "宛名") %></td>
-                        <td><%= f.text_field :receiver, class: "form-control" %></td>
-                    </tr>
-                </tbody>
-            </table>
+    <div class="row">
+        <div class="col-xs-offset-2">
+            <h4>お届け先</h4>
+            <div class="addressee">
+                <table class="addressee-form-table">
+                    <tbody>
+                        <tr>
+                            <%= radio_button_tag :address, "ご自身の住所", checked: true %>
+                            <%= f.label(:address, "ご自身の住所") %>
+                            <p class="address">
+                                <%= current_client.post_number %>
+                                <%= current_client.address %>
+                                <%= current_client.get_full_name %>
+                            </p>
+                        </tr>
+                        <tr>
+                            <%= radio_button_tag :address, "登録済住所から選択" %>
+                            <%= f.label(:receiver, "登録済住所から選択") %>
+                            <%= f.fields_for @delivery do |t| %>
+                            <p class="address">
+                                <%= select_tag 'delivery_id', options_for_select(current_client.deliveries.map { |delivery| [delivery.post_number + " " + delivery.address + " " + delivery.receiver, delivery.id] }) %>
+                            </p>
+                            <% end %>
+                        </tr>
+                        <tr>
+                            <%= radio_button_tag :address, "新しいお届け先" %>
+                            <%= f.label(:address, "新しいお届け先") %>
+                        </tr>
+                        <tr>
+                            <td><%= f.label(:post_number, "郵便番号") %></td>
+                            <td><%= f.text_field :post_number, class: "form-control" %></td>
+                        </tr>
+                        <tr>
+                            <td><%= f.label(:address, "住所") %></td>
+                            <td><%= f.text_field :address, class: "form-control" %></td>
+                        </tr>
+                        <tr>
+                            <td><%= f.label(:receiver, "宛名") %></td>
+                            <td><%= f.text_field :receiver, class: "form-control" %></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-</div>
 
-<div class="row">
-    <div class="col-xs-offset-5">
-        <%= f.submit '確認画面へ進む', class: "btn btn-primary" %>
-        <% end %>
+    <div class="row">
+        <div class="col-xs-offset-5">
+            <%= f.submit '確認画面へ進む', class: "btn btn-primary" %>
+        </div>
     </div>
-</div>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -235,7 +235,7 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
-      short: "%y/%m/%d"
+      short: "%Y/%m/%d"
       date: "%Y年%m月%d日 %H時%M分%S秒"
     pm: 午後
   attributes:

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -11,4 +11,9 @@ FactoryBot.define do
     email {'hoge@example.com'}
     password {'password'}
   end
+  factory :client2, parent: :client do
+    family_name {'太郎'}
+    family_name_kana {'タロウ'}
+    email {'test@example.com'}
+  end
 end

--- a/spec/factories/genres.rb
+++ b/spec/factories/genres.rb
@@ -3,4 +3,7 @@ FactoryBot.define do
     name {'ケーキ'}
     is_valid {'true'}
   end
+  factory :genre2, parent: :genre do
+    name {'プリン'}
+  end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,8 +2,13 @@ FactoryBot.define do
   factory :item do
     name {'苺のケーキ'}
     context {'季節の苺を使用した、お店自慢のケーキです。'}
-    price {'300'}
+    price {'800'}
     is_sale {'true'}
     genre
+  end
+  factory :item2, parent: :item do
+    name {'苺のプリン'}
+    context {'季節の苺を使用した、お店自慢のプリンです。'}
+    price {'600'}
   end
 end

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,5 +1,13 @@
 FactoryBot.define do
   factory :order_item do
-    
+    item_count {'4'}
+    price { '800' }
+    production_status {0}
+    order
+    item
+  end
+  factory :order_item2, parent: :order_item do
+    item_count {'2'}
+    price { '600' }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :order do
-    status {'0'}
-    payment_method {'0'}
+    status {0}
+    payment_method {0}
     postage {'800'}
-    total_fee {'1200'}
+    total_fee {'5552'}
     address {'東京都渋谷区神南1丁目19-11 パークスウェースクエア24階'}
     post_number {'1500041'}
     receiver {'山田花子'}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,6 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -61,4 +60,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/system/from_production_to_shipping_spec.rb
+++ b/spec/system/from_production_to_shipping_spec.rb
@@ -1,0 +1,183 @@
+require 'rails_helper'
+
+RSpec.describe "制作から発送", type: :system do
+  let!(:client) { create :client }
+  let!(:genre) { create :genre }
+  let!(:item) { create :item, genre: genre }
+  let!(:genre2) { create :genre2 }
+  let!(:item2) { create :item2, genre: genre2 }
+  let!(:order) { create :order, client: client }
+
+  describe "制作から発送まで(管理者)" do
+    let!(:login_admin) { create :admin }
+    before do
+      create(:order_item, order: order, item: item )
+      create(:order_item2, order: order, item: item2 )
+      visit admin_root_path
+      click_link "ログイン"
+      fill_in "admin[email]",	with: login_admin.email
+      fill_in "admin[password]",	with: login_admin.password
+      click_button "ログイン"
+    end
+    context "管理者の注文情報確認画面の表示" do
+      it "メールアドレス・パスワードを入力しログインできること" do
+        expect(current_path).to eq admin_root_path
+        expect(page).to have_content "ログインしました"
+      end
+      it "ヘッダから注文履歴一覧へ画面遷移できること" do
+        click_on "注文履歴一覧"
+        expect(current_path).to eq admin_orders_path
+      end
+      it "注文履歴一覧から注文履歴詳細画面へ遷移できること" do
+        click_on "注文履歴一覧"
+        click_link "#{order.created_at.strftime('%Y/%m/%d %H:%M:%S')}"
+        expect(current_path).to eq admin_order_path(order)
+      end
+    end
+    context "注文情報の確認とステータス変更" do
+      before do
+        click_on "注文履歴一覧"
+        click_link "#{order.created_at.strftime('%Y/%m/%d %H:%M:%S')}"
+      end
+      it "注文ステータスを入金確認に更新した場合(更新後 注文:入金確認、製作:製作待ち)" do
+        select "入金確認", from: "status"
+        find('#order-status').click
+        expect(page).to have_select( "status", selected: "入金確認")
+        order.order_items.each do |orderItem|
+          expect(page).to have_select( "order_item[production_status]", selected: "製作待ち")
+        end
+      end
+      it "制作ステータスを製作中に更新した場合(更新後 注文:製作中)" do
+        select "入金確認", from: "status"
+        find('#order-status').click
+        @order_item = order.order_items.first
+        select "製作中", from: "order_item[production_status]", match: :first
+        find_by_id("orderItem-status-#{@order_item.id}").click
+        expect(page).to have_select( "status", selected: "製作中")
+      end
+      it "制作ステータスをすべて製作完了に更新した場合(更新後 注文:発送準備中)" do
+        select "入金確認", from: "status"
+        find('#order-status').click
+        select "製作中", from: "order_item[production_status]", match: :first
+        find_by_id("orderItem-status-#{order.order_items.first.id}").click
+        order.order_items.each do |orderItem|
+          within "#order-item-field-#{orderItem.id}" do
+            select "製作完了", from: "order_item[production_status]"
+            find_by_id("orderItem-status-#{orderItem.id}").click
+            expect(page).to have_select( "order_item[production_status]", selected: "製作完了")
+          end
+        end
+        expect(page).to have_select( "status", selected: "発送準備中")
+      end
+      it "注文ステータスを発送済みに更新した場合(更新後 注文:発送済み)" do
+        select "入金確認", from: "status"
+        find('#order-status').click
+        select "製作中", from: "order_item[production_status]", match: :first
+        find_by_id("orderItem-status-#{order.order_items.first.id}").click
+        order.order_items.each do |orderItem|
+          within "#order-item-field-#{orderItem.id}" do
+            select "製作完了", from: "order_item[production_status]"
+            find_by_id("orderItem-status-#{orderItem.id}").click
+            expect(page).to have_select( "order_item[production_status]", selected: "製作完了")
+          end
+        end
+        select "発送済み", from: "status"
+        find('#order-status').click
+        expect(page).to have_select( "status", selected: "発送済み")
+      end
+    end
+    context "管理者アカウントのログアウト" do
+      it "ログアウト後に管理者ログイン画面へ遷移していること" do
+        click_on "ログアウト"
+        expect(current_path).to eq new_admin_session_path
+      end
+    end
+  end
+
+  describe "ECサイト(会員)）" do
+    before do
+      order.update(status: 4)
+      create(:order_item, production_status: 3, order: order, item: item )
+      create(:order_item2, production_status: 3, order: order, item: item2 )
+      visit new_client_session_path
+      fill_in "client[email]",	with: client.email
+      fill_in "client[password]",	with: client.password
+      click_button "ログイン"
+    end
+    context "会員ログイン" do
+      it "ログイン後にトップ画面へ遷移していること" do expect(current_path).to eq root_path end
+      it "ログイン後にヘッダー表示が変わっていること" do
+        expect(page).to have_content "ようこそ、#{client.get_full_name}さん！"
+      end
+      it "ヘッダーからマイページへ遷移できること" do
+        click_on "マイページ"
+        expect(current_path).to eq client_path(client)
+      end
+    end
+    context "会員マイページ" do
+      before do
+        click_on "マイページ"
+      end
+      it "マイページの会員情報が正しく表示されていること" do
+        expect(page).to have_content "#{client.first_name} #{client.family_name}"
+        expect(page).to have_content "#{client.first_name_kana} #{client.family_name_kana}"
+        expect(page).to have_content client.post_number
+        expect(page).to have_content client.address
+        expect(page).to have_content client.tel
+        expect(page).to have_content client.email
+      end
+      it "注文履歴一覧画面へ遷移できること" do
+        first("a[href='#{orders_path}']").click
+        expect(current_path).to eq orders_path
+      end
+    end
+    context "注文履歴一覧画面" do
+      before do
+        click_on "マイページ"
+        first("a[href='#{orders_path}']").click
+      end
+      it "注文履歴一覧画面の内容が正しく表示されていること" do
+        @orders = client.orders
+        within "tbody" do
+          @orders.each do |order|
+            expect(page).to have_content order.created_at.strftime('%Y/%m/%d')
+            expect(page).to have_content order.post_number
+            expect(page).to have_content order.address
+            expect(page).to have_content order.receiver
+            order.items.each{|item| expect(page).to have_content item.name }
+            expect(page).to have_content order.total_fee
+            expect(page).to have_content order.status_i18n
+          end
+        end
+      end
+    end
+    context "注文履歴詳細画面" do
+      before do
+        click_on "マイページ"
+        first("a[href='#{orders_path}']").click
+        first("a[href='#{order_path(order)}']").click
+      end
+      it "注文情報が正しく表示されていること" do
+        expect(page).to have_content order.created_at.strftime('%Y/%m/%d')
+        expect(page).to have_content order.post_number
+        expect(page).to have_content order.address
+        expect(page).to have_content order.receiver
+        expect(page).to have_content order.payment_method_i18n
+        expect(page).to have_content order.status_i18n
+      end
+      it "請求情報が正しく表示されていること" do
+        expect(page).to have_content (order.total_fee - order.postage)
+        expect(page).to have_content order.postage
+        expect(page).to have_content order.total_fee
+      end
+      it "注文内容が正しく表示されていること" do
+        order.order_items.each do |order_item|
+          expect(page).to have_content order_item.item.name
+          expect(page).to have_content order_item.price
+          expect(page).to have_content order_item.item_count
+          expect(page).to have_content order_item.subtotal
+        end
+      end
+    end
+  end
+end

--- a/spec/system/master_registration_spec.rb
+++ b/spec/system/master_registration_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "マスタ登録（管理者）", type: :system do
   end
 
   describe "商品画面" do
-    let(:genre) { create :genre }
+    let!(:genre) { create :genre }
     before { visit admin_items_path }
 
     context "商品新規登録画面の表示" do

--- a/spec/system/order_form_registration_spec.rb
+++ b/spec/system/order_form_registration_spec.rb
@@ -1,0 +1,249 @@
+require 'rails_helper'
+
+RSpec.describe "登録から注文(ECサイト)", type: :system do
+  
+  let!(:client) { create :client }
+  let!(:genre) { create :genre }
+  let!(:item) { create :item, genre: genre }
+  let!(:genre2) { create :genre2 }
+  let!(:item2) { create :item2, genre: genre2 }
+  let!(:delivery) { create :delivery, client: client }
+
+  before do |login|
+    unless login.metadata[:skip_login]
+      visit new_client_session_path
+      fill_in "client[email]",	with: client.email
+      fill_in "client[password]",	with: client.password
+      click_button "ログイン"
+    end
+  end
+
+  describe "ECサイトの会員登録", :skip_login do
+    let!(:new_client) { build :client2}
+    before { visit root_path }
+
+    context "画面遷移" do
+      it "会員ECサイトのトップ画面から新規登録画面へ遷移できること" do
+        click_on "新規登録"
+        expect(current_path).to eq new_client_registration_path
+      end
+    end
+    
+    context "新規アカウント登録" do
+      before do
+        within "header" do
+          click_link "新規登録"
+        end
+        fill_in "client[first_name]",	with: new_client.first_name
+        fill_in "client[family_name]",	with: new_client.family_name
+        fill_in "client[first_name_kana]",	with: new_client.first_name_kana
+        fill_in "client[family_name_kana]",	with: new_client.family_name_kana
+        fill_in "client[email]",	with: new_client.email
+        fill_in "client[post_number]",	with: new_client.post_number
+        fill_in "client[address]",	with: new_client.address
+        fill_in "client[tel]",	with: new_client.tel
+        fill_in "client[password]",	with: new_client.password
+        fill_in "client[password_confirmation]",	with: new_client.password
+        click_button "新規登録"
+      end
+      it "新規登録した会員が問題なく登録できていること" do
+        @client_db = Client.find_by(email: new_client.email)
+        expect(new_client.email).to eq @client_db.email 
+      end
+      it "アカウント登録後にトップ画面へ遷移していること" do expect(current_path).to eq root_path end
+      it "アカウント登録完了メッセージが表示されていること" do expect(page).to have_content "アカウント登録が完了" end
+    end
+  end
+
+  describe "商品の選択とカート追加" do
+    context "トップ画面から任意の商品画像を選択" do
+      before { first("a[href='#{item_path(item)}']").click }
+      it "選択した商品詳細画面へ遷移していること" do expect(current_path).to eq item_path(item) end
+      it "選択した商品情報が正しく詳細画面に表示されていること" do
+        expect(page.find("tbody")).to have_content item.genre.name
+        expect(page).to have_content item.name
+        expect(page).to have_content item.context
+        expect(page).to have_content item.price
+      end
+    end
+    context "トップ画面から該当商品(1個目)を選択してカートに追加" do
+      before do
+        first("a[href='#{item_path(item)}']").click
+        select 4, from: "cart_item[item_count]"
+        click_on "カートに入れる"
+      end
+      it "カートに入れるボタン押下でカート画面へ遷移していること" do
+        expect(current_path).to eq cart_items_path
+        expect(page).to have_content "ショッピングカート"
+      end
+      it "カートに入れた商品情報が正しく画面にて表示されていること" do
+        @cart_item = CartItem.find_by(item_id: item.id, client_id: client.id)
+        within "tbody" do
+          expect(page).to have_content @cart_item.item.name
+          expect(page).to have_content @cart_item.item.price_tax_included
+          have_field "cart_item[item_count]", with: @cart_item.item_count 
+          expect(page).to have_content @cart_item.subtotal
+        end
+      end
+      it "買い物を続けるボタン押下でトップ画面へ遷移していること" do
+        click_on "買い物を続ける"
+        expect(current_path).to eq root_path
+      end      
+    end
+    context "商品一覧から該当商品(2個目)を選択してカートに追加" do
+      let!(:cart_item1) { create :cart_item, client: client, item: item, item_count: 4}
+      before do
+        click_link "商品一覧"
+        first("a[href='#{item_path(item2)}']").click
+        select 2, from: "cart_item[item_count]"
+        click_on "カートに入れる"
+      end
+      it "カートに入れるボタン押下でカート画面へ遷移していること" do
+        expect(current_path).to eq cart_items_path
+        expect(page).to have_content "ショッピングカート"
+      end
+      it "カートに入れた商品情報が正しく画面にて表示されていること" do
+        @cart_item2 = CartItem.find_by(item_id: item2.id, client_id: client.id)
+        within "tbody" do
+          expect(page).to have_content @cart_item2.item.name
+          expect(page).to have_content @cart_item2.item.price_tax_included
+          have_field "cart_item[item_count]", with: @cart_item2.item_count 
+          expect(page).to have_content @cart_item2.subtotal
+        end
+      end
+      it "合計金額が正しく表示されていること" do
+        expect(page).to have_content client.cart_items.inject(0){ |total,cart_item| total += cart_item.subtotal }
+      end
+      it "情報入力に進むボタン押下で注文情報入力画面へ遷移していること" do
+        click_on "情報入力に進む"
+        expect(current_path).to eq new_order_path
+      end      
+    end
+  end
+  
+  describe "注文情報の入力から注文確定" do
+    let!(:cart_item1) { create :cart_item, client: client, item: item, item_count: 4}
+    let!(:cart_item2) { create :cart_item, client: client, item: item2, item_count: 2}
+    before do
+      visit cart_items_path
+      click_on "情報入力に進む"
+    end
+    context "注文情報入力画面を表示" do
+      it "支払方法が正しく表示されていること" do
+        expect(page).to have_checked_field "order[payment_method]", with: "credit_card"
+        expect(page).to have_unchecked_field "order[payment_method]", with: "bank_transfer"
+      end
+      it "お届け先が正しく表示されていること" do
+        expect(page).to have_checked_field "address", with: "ご自身の住所"
+        expect(page).to have_unchecked_field "address", with: "登録済住所から選択"
+        expect(page).to have_unchecked_field "address", with: "新しいお届け先"
+        expect(page).to have_content client.post_number
+        expect(page).to have_content client.address
+        expect(page).to have_content client.get_full_name
+        expect(page).to have_select( "delivery_id", options: ["#{delivery.post_number} #{delivery.address} #{delivery.receiver}"])
+      end
+    end
+    context "注文内容確認画面を表示" do
+      before do
+        find("input[name='order[payment_method]'][value='credit_card']").set(true)
+        find("input[name='address'][value='ご自身の住所']").set(true)
+        click_on "確認画面へ進む"
+        @cart_items = client.cart_items
+      end
+      it "確認画面へ進むボタン押下で注文確認画面へ遷移していること" do expect(current_path).to eq confirm_orders_path end
+      it "カート商品の内容が正しく表示されていること" do
+        @cart_items.each do |cart_item|
+          expect(page).to have_content cart_item.item.name
+          expect(page).to have_content cart_item.item.price_tax_included
+          expect(page).to have_content cart_item.item_count
+          expect(page).to have_content cart_item.subtotal
+        end
+      end
+      it "送料・商品合計・請求金額が正しく表示されていること" do
+        # 送料
+        expect(page).to have_content 800
+        # 商品合計金額
+        @total_item_price = @cart_items.inject(0){|total,cart_item| total += cart_item.subtotal}
+        expect(page).to have_content @total_item_price
+        # 請求合計金額
+        expect(page).to have_content (@total_item_price + 800)
+      end
+      it "購入を確定するボタン押下で注文情報が登録されていること" do
+        expect{ click_on "購入を確定する" }.to change{ client.orders.count }.by(1)
+      end
+      it "購入を確定するボタン押下でサンクスページへ遷移していること" do
+        click_on "購入を確定する"
+        expect(page).to have_content "ご購入ありがとうございました"
+      end
+      it "サンクスページからマイページへ画面遷移できること" do
+        click_on "購入を確定する"
+        click_link "マイページ"
+        expect(current_path).to eq client_path(client)
+      end
+    end
+  end
+
+  describe "注文履歴画面で注文内容を確認" do
+    let!(:cart_item1) { create :cart_item, client: client, item: item, item_count: 4}
+    let!(:cart_item2) { create :cart_item, client: client, item: item2, item_count: 2}
+    before do
+      # 一連の注文処理を再現
+      visit cart_items_path
+      click_on "情報入力に進む"
+      find("input[name='order[payment_method]'][value='credit_card']").set(true)
+      find("input[name='address'][value='ご自身の住所']").set(true)
+      click_on "確認画面へ進む"
+      click_on "購入を確定する"
+      click_on "マイページ"
+      first("a[href='#{orders_path}']").click
+    end
+    context "注文履歴一覧画面を表示" do
+      it "マイページから注文履歴一覧へ遷移できること" do expect(current_path).to eq orders_path end
+      it "注文履歴一覧の内容が正しく表示されていること" do
+        @orders = client.orders
+        @orders.each do |order|
+          expect(page).to have_content order.created_at.strftime('%Y/%m/%d')
+          expect(page).to have_content order.post_number
+          expect(page).to have_content order.address
+          expect(page).to have_content order.receiver
+          expect(page).to have_content order.total_fee
+          expect(page).to have_content "入金待ち"
+          # すべての注文商品名
+          order.order_items.each do |order_item|
+            expect(page).to have_content order_item.item.name
+          end
+        end
+      end
+    end
+    context "注文履歴詳細画面を表示" do
+      before do
+        @order = client.orders.first
+        first("a[href='#{order_path(@order)}']").click
+      end
+      it "注文履歴一覧から注文履歴詳細画面へ遷移できること" do expect(current_path).to eq order_path(@order) end
+      it "注文情報が正しく表示されていること" do
+        expect(page).to have_content @order.created_at.strftime('%Y/%m/%d')
+        expect(page).to have_content @order.post_number
+        expect(page).to have_content @order.address
+        expect(page).to have_content @order.receiver
+        expect(page).to have_content @order.payment_method_i18n
+        expect(page).to have_content "入金待ち"
+      end
+      it "請求情報が正しく表示されていること" do
+        expect(page).to have_content (@order.total_fee -  @order.postage)
+        expect(page).to have_content @order.postage
+        expect(page).to have_content @order.total_fee
+      end
+      it "注文内容が正しく表示されていること" do
+        within "tbody" do
+          @order.order_items.each do |order_item|
+            expect(page).to have_content order_item.item.name
+            expect(page).to have_content order_item.price
+            expect(page).to have_content order_item.item_count
+            expect(page).to have_content order_item.subtotal
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Rspecテストシナリオ追加＆注文機能画面レイアウト修正
- テストシナリオ：②登録〜注文、③製作〜発送を追加　※トップ画面商品が未実装のため一部エラー発生
- 注文機能画面にてレイアウト及びボタン押下の不具合を修正
- 注文履歴画面にID属性を付与
- ja.ymlにて日時フォーマットを一部修正 ※年月日の年を４桁で表示するように修正
- itemモデルに注文回数が多い順に取得するメソッドを追加