### PR TITLE
修正

### DIFF
--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -14,7 +14,6 @@ class Admin::OrderItemsController < ApplicationController
                 end
             end
             if @order.order_items.count == finish_count
-                logger.debug "order: #{@order.attributes.inspect}"
                 @order.update(status: :preparation) 
             end
                 redirect_to admin_order_path(@order)

--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -14,6 +14,7 @@ class Admin::OrderItemsController < ApplicationController
                 end
             end
             if @order.order_items.count == finish_count
+                logger.debug "order: #{@order.attributes.inspect}"
                 @order.update(status: :preparation) 
             end
                 redirect_to admin_order_path(@order)

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -3,29 +3,27 @@ class Admin::OrdersController < Admin::Base
     protect_from_forgery
 
     def index
-        @orders = Order.all
+        case params[:order]
+        when 'today'
+            @orders = Order.where(created_at: Time.zone.now.beginning_of_day).page(params[:page]).per(10).order(created_at: :desc)
+        when 'all'
+            @orders = Order.page(params[:page]).per(10).order(created_at: :desc)
+        end
     end
 
     def show
         @order = Order.find(params[:id])
         @order_items = @order.order_items
-        # @order_price = @order.order_items.find_by(order_id: current_client.id)
     end
 
 
     def update
         @order = Order.find(params[:id])
-        # @orderitem = OrderItem.where(order_id: @order.id)
-        if @order.update_attributes(order_params)
+        if @order.update(order_params)
             if @order.paid?
                 OrderItem.where(order_id: @order.id).update_all(production_status: :wait_for_product)
             end
             redirect_to admin_order_path(@order)
-            # case @order.status
-            # when @order.paid?
-            #     OrderItem.where(order_id: @order.id).update_all(production_status: :wait_for_production)
-            # end
-            # redirect_to admin_order_path(@order)
         else
             @order_items = @order.order_items
             render 'show'

--- a/app/controllers/client/orders_controller.rb
+++ b/app/controllers/client/orders_controller.rb
@@ -36,9 +36,8 @@ class Client::OrdersController < Client::Base
   end
 
   def index
-    @orders = Order.where(client_id: current_client.id)
+    @orders = Order.where(client_id: current_client.id).page(params[:page]).per(5).order(created_at: :desc)
     # current_client.orders
-    # @order = OrderItem.where(order_id: current_client.id)
   end
 
   def new

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,52 +11,6 @@ belongs_to :client
 enum status: { waiting: 0, paid: 1, in_production: 2, preparation: 3, shipped: 4}
 enum payment_method:{ credit_card: 0, bank_transfer: 1}
 
-validate :check_order_item_status
-
-def  check_order_item_status
-    order_items = self.order_items
-    if self.waiting?
-        order_items.each do |order_item|
-            unless order_item.production_status == :unable
-                errors.add(:status, "制作ステータスが着手不可以外なので更新できません")
-            end
-        end
-    elsif self.preparation?
-        order_items.each do |order_item|
-            unless order_item.production_status == :finish
-                errors.add(:status, "製作完了してないので更新できません")
-            end
-        end
-    elsif self.shipped?
-        order_items.each do |order_item|
-            unless order_item.production_status == :finish
-                errors.add(:status, "製作完了していないので更新できません")
-            end
-        end
-    end
-end
-    # case self.status
-    # when :waiting
-    #     order_items.each do |order_item|
-    #         unless order_item.production_status == :unable
-    #             errors.add(:waiting, "更新できません")
-    #         end
-    #     end
-    # when :preparation
-#         order_items.each do |order_item|
-#             unless order_item.production_status == :finish
-#                 errors.add(:waiting, "更新できません")
-#             end
-#         end
-#     when :finish
-#         order_items.each do |order_item|
-#             unless order_item.production_status == :finish
-#                 errors.add(:waiting, "更新できません")
-#             end
-#         end
-#     end
-# end
-
 def all_shipping_info
     self.post_number + "    " + self.address + "<br>" + self.receiver
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,15 +3,59 @@ class Order < ApplicationRecord
 # 今日登録された情報を抽出
 scope :created_today, -> { where( "created_at >= ?", Time.zone.now.beginning_of_day)}
 
-enum status: { waiting: 0, paid: 1, in_production: 2, preparation: 3, shipped: 4}
-
 has_many :order_items
 has_many :items, through: :order_items
-# accepts_nested_attributes_for :order_items
 
 belongs_to :client
 
+enum status: { waiting: 0, paid: 1, in_production: 2, preparation: 3, shipped: 4}
 enum payment_method:{ credit_card: 0, bank_transfer: 1}
+
+validate :check_order_item_status
+
+def  check_order_item_status
+    order_items = self.order_items
+    if self.waiting?
+        order_items.each do |order_item|
+            unless order_item.production_status == :unable
+                errors.add(:status, "制作ステータスが着手不可以外なので更新できません")
+            end
+        end
+    elsif self.preparation?
+        order_items.each do |order_item|
+            unless order_item.production_status == :finish
+                errors.add(:status, "製作完了してないので更新できません")
+            end
+        end
+    elsif self.shipped?
+        order_items.each do |order_item|
+            unless order_item.production_status == :finish
+                errors.add(:status, "製作完了していないので更新できません")
+            end
+        end
+    end
+end
+    # case self.status
+    # when :waiting
+    #     order_items.each do |order_item|
+    #         unless order_item.production_status == :unable
+    #             errors.add(:waiting, "更新できません")
+    #         end
+    #     end
+    # when :preparation
+#         order_items.each do |order_item|
+#             unless order_item.production_status == :finish
+#                 errors.add(:waiting, "更新できません")
+#             end
+#         end
+#     when :finish
+#         order_items.each do |order_item|
+#             unless order_item.production_status == :finish
+#                 errors.add(:waiting, "更新できません")
+#             end
+#         end
+#     end
+# end
 
 def all_shipping_info
     self.post_number + "    " + self.address + "<br>" + self.receiver

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -11,10 +11,4 @@ class OrderItem < ApplicationRecord
         CommonOrder.calc_subtotal(item_price: self.price, item_count: self.item_count)
     end
 
-    # def subtotal
-    #     itemprice = self.price * 1.08
-    #     (itemprice * self.item_count).to_i
-    # end
-
-
 end

--- a/app/views/admin/_header.html.erb
+++ b/app/views/admin/_header.html.erb
@@ -3,11 +3,11 @@
   <div class="container">
     <nav class="nav navbar-nav navbar-left">
        <% if admin_signed_in? %>
-         <%= link_to(root_path) do %>
+         <%= link_to(admin_root_path) do %>
             <%= image_tag 'rogo-cream',:size => '310x60' %>
          <% end %>
       <% else %>
-         <%= link_to(root_path) do %>
+         <%= link_to(admin_root_path) do %>
             <%= image_tag 'rogo',:size => '310x50' %>
          <% end %>
       <% end %>
@@ -17,7 +17,7 @@
         <% if admin_signed_in? %>
           <li><%= link_to ' 商品一覧', admin_items_path, class: 'glyphicon glyphicon-picture picture' %></li>
           <li><%= link_to ' 会員一覧', admin_clients_path, class: 'glyphicon glyphicon-user user' %></li>
-          <li><%= link_to ' 注文履歴一覧', admin_orders_path, class: 'glyphicon glyphicon-file file' %></li>
+          <li><%= link_to ' 注文履歴一覧', admin_orders_path(order: 'all'), class: 'glyphicon glyphicon-file file' %></li>
           <li><%= link_to ' ジャンル一覧', admin_genres_path, class: 'glyphicon glyphicon-list-alt list-alt' %></li>
           <li><%= link_to ' ログアウト', destroy_admin_session_path, method: :delete, class: 'glyphicon glyphicon-log-out log-out' %></li>
         <% else %>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -20,9 +20,9 @@
                             <td><%=  order.status_i18n %></td>
                         </tr>
                     <% end %>
+                        <%= paginate @orders %>
                 <% end %>
             </tbody>
         </table>
     </div>
 </div>
-

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,3 +1,5 @@
+<%= render 'layouts/error_messages', model: @order %>
+
 <div class="row">
     <div class="col-xs-offset-1">
         <h3 class="order-text col-xs-3">注文履歴詳細</h3>

--- a/app/views/admin/top/top.html.erb
+++ b/app/views/admin/top/top.html.erb
@@ -2,6 +2,6 @@
 <div class="row">
   <h1>管理者画面</h1>
   <div class="col-xs-6 col-xs-offset-3 text-left">
-    <p class="lead">本日の注文件数：<%= link_to "#{@orders.count}件", admin_orders_path %></p>
+    <p class="lead">本日の注文件数：<%= link_to "#{@orders.count}件", admin_orders_path(order: 'today') %></p>
   </div>
 </div>

--- a/app/views/client/orders/index.html.erb
+++ b/app/views/client/orders/index.html.erb
@@ -21,20 +21,21 @@
             </thead>
             <tbody>
                 <% if @orders.any? %>
-                    <% @orders.each do |order| %>
-                        <tr>
-                            <td><%= l order.created_at, format: :short %></td>
-                            <td><%= order.all_shipping_info.html_safe %></td>
-                            <td>
-                                <% order.items.each do |item_name| %>
-                                    <%= item_name.name %><br>
-                                <% end %>
-                            </td>
-                            <td><%= order.total_fee %></td>
-                            <td><%= order.status_i18n %></td>
-                            <td><%= link_to '表示する', order_path(order), class: "btn origin-btn" %></td>
-                        </tr>
-                    <% end %>
+                        <% @orders.each do |order| %>
+                            <tr>
+                                <td><%= l order.created_at, format: :short %></td>
+                                <td><%= order.all_shipping_info.html_safe %></td>
+                                <td>
+                                    <% order.items.each do |item_name| %>
+                                        <%= item_name.name %><br>
+                                    <% end %>
+                                </td>
+                                <td><%= order.total_fee %></td>
+                                <td><%= order.status_i18n %></td>
+                                <td><%= link_to '表示する', order_path(order), class: "btn origin-btn" %></td>
+                            </tr>
+                        <% end %>
+                    <%= paginate @orders %>
                 <% end %>
             </tbody>
         </table>


### PR DESCRIPTION
注文情報を降順で表示
ページネーション機能の追加
adminの注文履歴を本日からの注文リンクから遷移してきた場合に本日の注文のみ表示。ヘッダーからは全部表示。