### PR TITLE
[Update]カートアイテム画像表示、商品登録&編集の金額入力欄にオプション追加

### DIFF
--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -29,7 +29,7 @@
 
      <div class="field">
 	     <%= f.label :price, "税抜金額" %>
-	     <%= f.text_field :price, data: { autonumeric: true },class: "price" %> 円
+	     <%= f.text_field :price, data: { autonumeric: true, mDec: 0 },class: "price" %> 円
      </div>
 
 

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -29,7 +29,7 @@
 
     <div class="field">
 	     <%= f.label :price, "税抜金額" %>
-	     <%= f.text_field :price, data: { autonumeric: true },class: "price" %> 円
+	     <%= f.text_field :price, data: { autonumeric: true, mDec: 0 },class: "price" %> 円
     </div>
 
 

--- a/app/views/client/cart_items/index.html.erb
+++ b/app/views/client/cart_items/index.html.erb
@@ -33,7 +33,7 @@
 			<% if @cart_items.present? %>
 		        <% @cart_items.each do |cart_item| %>
 		            <tr>
-			            <td><%= attachment_image_tag(@item, :image, format: 'jpeg', size: '100x100', fallback: "no_image.jpg") %>
+			            <td><%= attachment_image_tag(cart_item.item, :image, format: 'jpeg', size: '100x100', fallback: "no_image.jpg") %>
 			                <%= cart_item.item.name %></td>
 			            <td id="cart_item"><%= cart_item.item.price_tax_included %></td>
 			            <td id="cart_item"><%= form_for(cart_item) do |f| %>


### PR DESCRIPTION
#42　[Update]カートアイテム画像表示、商品登録&編集の金額入力欄にオプション追加

- カートにアイテムモデルが保持している商品画像を表示させるように変更

- 商品の金額入力欄にオプションを追加